### PR TITLE
stratum: disable haproxy ip translation code by default

### DIFF
--- a/stratum/socket.cpp
+++ b/stratum/socket.cpp
@@ -17,9 +17,9 @@ void socket_real_ip(YAAMP_SOCKET *s)
 		ret = recv(s->sock, &hdr, sizeof(hdr), MSG_PEEK);
 	} while (ret == -1 && errno == EINTR);
 
-	if (ret >= (16 + ntohs(hdr.v2.len)) && 
-		memcmp(&hdr.v2, v2sig, 12) == 0 && 
-		((hdr.v2.ver_cmd & 0xF0) == 0x20) && 
+	if (ret >= (16 + ntohs(hdr.v2.len)) &&
+		memcmp(&hdr.v2, v2sig, 12) == 0 &&
+		((hdr.v2.ver_cmd & 0xF0) == 0x20) &&
 		hdr.v2.fam == 0x11) {
 		// we received a proxy v2 header
 		inet_ntop(AF_INET, &hdr.v2.addr.ip4.src_addr, s->ip, 64);
@@ -58,8 +58,20 @@ YAAMP_SOCKET *socket_initialize(int sock)
 
 //	yaamp_create_mutex(&s->mutex);
 //	pthread_mutex_lock(&s->mutex);
+	int res = 0;
+	if (!g_handle_haproxy_ips) {
+		struct sockaddr_in name;
+		socklen_t len = sizeof(name);
+		memset(&name, 0, len);
 
-	socket_real_ip(s);
+		res = getpeername(s->sock, (struct sockaddr *)&name, &len);
+		inet_ntop(AF_INET, &name.sin_addr, s->ip, 64);
+
+		res = getsockname(s->sock, (struct sockaddr *)&name, &len);
+		s->port = ntohs(name.sin_port);
+	} else {
+		socket_real_ip(s);
+	}
 
 	return s;
 }
@@ -202,7 +214,6 @@ int socket_send(YAAMP_SOCKET *s, const char *format, ...)
 
 //	pthread_mutex_lock(&s->mutex);
 	int res = socket_send_raw(s, buffer, strlen(buffer));
-
 //	pthread_mutex_unlock(&s->mutex);
 	return res;
 }

--- a/stratum/stratum.cpp
+++ b/stratum/stratum.cpp
@@ -39,6 +39,8 @@ bool g_stratum_segwit = false;
 
 int g_limit_txs_per_block = 0;
 
+bool g_handle_haproxy_ips = false;
+
 bool g_debuglog_client;
 bool g_debuglog_hash;
 bool g_debuglog_socket;
@@ -245,7 +247,9 @@ int main(int argc, char **argv)
 	g_stratum_max_ttf = iniparser_getint(ini, "STRATUM:max_ttf", 0x70000000);
 	g_stratum_reconnect = iniparser_getint(ini, "STRATUM:reconnect", true);
 	g_stratum_renting = iniparser_getint(ini, "STRATUM:renting", true);
+	g_handle_haproxy_ips = iniparser_getint(ini, "STRATUM:haproxy_ips", g_handle_haproxy_ips);
 
+	g_max_shares = iniparser_getint(ini, "STRATUM:max_shares", g_max_shares);
 	g_limit_txs_per_block = iniparser_getint(ini, "STRATUM:max_txs_per_block", 0);
 
 	g_debuglog_client = iniparser_getint(ini, "DEBUGLOG:client", false);

--- a/stratum/stratum.h
+++ b/stratum/stratum.h
@@ -90,6 +90,8 @@ extern bool g_stratum_renting;
 extern bool g_stratum_segwit;
 extern int g_limit_txs_per_block;
 
+extern bool g_handle_haproxy_ips;
+
 extern bool g_debuglog_client;
 extern bool g_debuglog_hash;
 extern bool g_debuglog_socket;


### PR DESCRIPTION
toggle it via the .conf or edit code to change overall defaults