### PR TITLE
stratum: ensure all blocks are put in db (#241)

### DIFF
--- a/stratum/client.cpp
+++ b/stratum/client.cpp
@@ -298,7 +298,9 @@ bool client_update_block(YAAMP_CLIENT *client, json_value *json_params)
 		return false;
 	}
 
-	YAAMP_COIND *coind = (YAAMP_COIND *)object_find(&g_list_coind, json_params->u.array.values[1]->u.integer, true);
+	int coinid = json_params->u.array.values[1]->u.integer;
+	if(!coinid) return false;
+	YAAMP_COIND *coind = (YAAMP_COIND *)object_find(&g_list_coind, coinid, true);
 	if(!coind) return false;
 
 	const char* hash = json_params->u.array.values[2]->u.string.ptr;
@@ -306,6 +308,8 @@ bool client_update_block(YAAMP_CLIENT *client, json_value *json_params)
 	if (g_debuglog_client) {
 		debuglog("notify: new %s block %s\n", coind->symbol, hash);
 	}
+
+	snprintf(coind->lastnotifyhash, 161, "%s", hash);
 
 	coind->newblock = true;
 	coind->notreportingcounter = 0;

--- a/stratum/client_submit.cpp
+++ b/stratum/client_submit.cpp
@@ -277,10 +277,12 @@ static void client_do_submit(YAAMP_CLIENT *client, YAAMP_JOB *job, YAAMP_JOB_VAL
 				target_to_diff(coin_target), target_to_diff(hash_int),
 				hash1, submitvalues->hash_be, templ->has_segwit_txs);
 
-			if(coind->noblocknotify) {
-				// DCR go wallet doesnt handle blocknotify= config (yet)
-				// required to store the user id and the user diff
+			if(!strcmp("DCR", coind->rpcencoding)) {
+				// delay between dcrd and dcrwallet
 				sleep(1);
+			}
+
+			if(!strcmp(coind->lastnotifyhash,submitvalues->hash_be)) {
 				block_confirm(coind->id, submitvalues->hash_be);
 			}
 

--- a/stratum/coind.cpp
+++ b/stratum/coind.cpp
@@ -165,7 +165,6 @@ void coind_init(YAAMP_COIND *coind)
 	strcpy(account, coind->account);
 	if(!strcmp(coind->rpcencoding, "DCR")) {
 		coind->usegetwork = true;
-		//coind->noblocknotify = true;
 		//sprintf(account, "default");
 	}
 

--- a/stratum/coind.h
+++ b/stratum/coind.h
@@ -47,6 +47,7 @@ public:
 	bool enable;
 	bool auto_ready;
 	bool newblock;
+	char lastnotifyhash[192];
 
 	int height;
 	double difficulty;
@@ -66,7 +67,6 @@ public:
 	bool usememorypool;
 	bool hasmasternodes;
 	bool oldmasternodes;
-	bool noblocknotify;
 	bool multialgos; // pow_hash field (or mined_hash)
 
 	bool usesegwit;

--- a/stratum/share.cpp
+++ b/stratum/share.cpp
@@ -232,10 +232,10 @@ void block_add(int userid, int workerid, int coinid, int height, double diff, do
 }
 
 // called from blocknotify tool
-void block_confirm(int coinid, const char *blockhash)
+bool block_confirm(int coinid, const char *blockhash)
 {
 	char hash[192];
-	if(strlen(blockhash) < 64) return;
+	if(strlen(blockhash) < 64) return false;
 
 	snprintf(hash, 161, "%s", blockhash);
 
@@ -290,17 +290,18 @@ void block_confirm(int coinid, const char *blockhash)
 	for(CLI li = g_list_block.first; li; li = li->next)
 	{
 		YAAMP_BLOCK *block = (YAAMP_BLOCK *)li->data;
-		if(block->coinid == coinid && !block->confirmed && !block->deleted)
+		if(block->coinid == coinid && !block->deleted)
 		{
 			if(strcmp(block->hash1, hash) && strcmp(block->hash2, hash)) continue;
-			debuglog("*** CONFIRMED %d : %s\n", block->height, block->hash2);
-
-			strncpy(block->hash, blockhash, 65);
-			block->confirmed = true;
-
-			return;
+			if (!block->confirmed) {
+				debuglog("*** CONFIRMED %d : %s\n", block->height, block->hash2);
+				strncpy(block->hash, blockhash, 65);
+				block->confirmed = true;
+			}
+			return true;
 		}
 	}
+	return false;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/stratum/share.h
+++ b/stratum/share.h
@@ -100,7 +100,7 @@ inline void submit_delete(YAAMP_OBJECT *object)
 void block_prune(YAAMP_DB *db);
 
 void block_add(int userid, int workerid, int coinid, int height, double diff, double diff_user, const char *hash1, const char *h2, int segwit);
-void block_confirm(int coinid, const char *hash);
+bool block_confirm(int coinid, const char *hash);
 
 YAAMP_SUBMIT *submit_add(int remoteid, double difficulty);
 void submit_prune(YAAMP_DB *db);


### PR DESCRIPTION
may be important for pool op noobs who dunno what they do,
doesn't setup blocknotify or have server efficiency issues..

squashed commit of today's commits, sorry for the mess ;)

prevent job delays if no blocks were submitted
double check coin id on blocknotify
remove noblocknotify boolean
prevent notify debuglog on normal blocks